### PR TITLE
DOC: Update citation to published Bioinformatics Advances paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A pre-trained transformer model for inference on insect DNA barcoding data.
   <img src ="Figures/Arch.jpg" alt="drawing" width="500"/>
 </p>
 
-Check out our [paper](https://doi.org/10.1093/bioadv/vbag054)
+Read our paper in [*Bioinformatics Advances*](https://doi.org/10.1093/bioadv/vbag054) (Millan Arias et al., 2026).
+If you use BarcodeBERT in your research, please consider [citing us](#citation).
 
 ### Using the model
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ If you find BarcodeBERT useful in your research please consider citing:
   journal={Bioinformatics Advances},
   pages={vbag054},
   year={2026},
-  month={02},
+  month = feb,
   doi={10.1093/bioadv/vbag054},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ for information about setup, code style, and submission process.
 If you find BarcodeBERT useful in your research please consider citing:
 
 ```bibtex
-@article{10.1093/bioadv/vbag054,
+@article{MillanArias2026BarcodeBERT,
   author={Millan Arias, Pablo and Sadjadi, Niousha and Safari, Monireh
     and Gong, ZeMing and Wang, Austin T and Haurum, Joakim Bruslund
     and Zarubiieva, Iuliia and Steinke, Dirk and Kari, Lila

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ A pre-trained transformer model for inference on insect DNA barcoding data.
   <img src ="Figures/Arch.jpg" alt="drawing" width="500"/>
 </p>
 
-Check out our [paper](https://arxiv.org/abs/2311.02401)
+Read our paper in
+[*Bioinformatics Advances*](https://doi.org/10.1093/bioadv/vbag054)
+(Millan Arias et al., 2026).
+If you use BarcodeBERT in your research,
+please consider [citing us](#citation).
 
 ### Using the model
 
@@ -123,26 +127,16 @@ for information about setup, code style, and submission process.
 If you find BarcodeBERT useful in your research please consider citing:
 
 ```bibtex
-@article{arias2023barcodebert,
-  title={{BarcodeBERT}: Transformers for Biodiversity Analysis},
-  author={Pablo Millan Arias
-    and Niousha Sadjadi
-    and Monireh Safari
-    and ZeMing Gong
-    and Austin T. Wang
-    and Joakim Bruslund Haurum
-    and Iuliia Zarubiieva
-    and Dirk Steinke
-    and Lila Kari
-    and Angel X. Chang
-    and Scott C. Lowe
-    and Graham W. Taylor
-  },
-  journal={arXiv preprint arXiv:2311.02401},
-  year={2023},
-  eprint={2311.02401},
-  archivePrefix={arXiv},
-  primaryClass={cs.LG},
-  doi={10.48550/arxiv.2311.02401},
+@article{10.1093/bioadv/vbag054,
+  author={Millan Arias, Pablo and Sadjadi, Niousha and Safari, Monireh
+    and Gong, ZeMing and Wang, Austin T and Haurum, Joakim Bruslund
+    and Zarubiieva, Iuliia and Steinke, Dirk and Kari, Lila
+    and Chang, Angel X and Lowe, Scott C and Taylor, Graham W},
+  title={{BarcodeBERT}: Transformers for Biodiversity Analyses},
+  journal={Bioinformatics Advances},
+  pages={vbag054},
+  year={2026},
+  month={02},
+  doi={10.1093/bioadv/vbag054},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A pre-trained transformer model for inference on insect DNA barcoding data.
   <img src ="Figures/Arch.jpg" alt="drawing" width="500"/>
 </p>
 
-Check out our [paper](https://arxiv.org/abs/2311.02401)
+Check out our [paper](https://doi.org/10.1093/bioadv/vbag054)
 
 ### Using the model
 
@@ -123,7 +123,7 @@ for information about setup, code style, and submission process.
 If you find BarcodeBERT useful in your research please consider citing:
 
 ```bibtex
-@article{arias2023barcodebert,
+@article{arias2026barcodebert,
   title={{BarcodeBERT}: Transformers for Biodiversity Analysis},
   author={Pablo Millan Arias
     and Niousha Sadjadi
@@ -138,11 +138,11 @@ If you find BarcodeBERT useful in your research please consider citing:
     and Scott C. Lowe
     and Graham W. Taylor
   },
-  journal={arXiv preprint arXiv:2311.02401},
-  year={2023},
-  eprint={2311.02401},
-  archivePrefix={arXiv},
-  primaryClass={cs.LG},
-  doi={10.48550/arxiv.2311.02401},
+  journal={Bioinformatics Advances},
+  pages={vbag054},
+  year={2026},
+  month={02},
+  issn={2635-0041},
+  doi={10.1093/bioadv/vbag054},
 }
 ```


### PR DESCRIPTION
## Summary

- Replace the arXiv preprint BibTeX citation with the published *Bioinformatics Advances* journal citation (Millan Arias et al., 2026)
- Update the "Check out our paper" line at the top of the README to link to the published DOI, include the citation, and point readers to the Citation section below

## Test plan

- [x] Verify the DOI link resolves: https://doi.org/10.1093/bioadv/vbag054
- [x] Verify the `#citation` anchor link works on the rendered README
- [x] Confirm the BibTeX block matches the publisher-provided citation